### PR TITLE
docs: Add documentation links for learning more about js

### DIFF
--- a/docs/further_reading/javascript_basics.mdx
+++ b/docs/further_reading/javascript_basics.mdx
@@ -1,0 +1,14 @@
+---
+id: javascript
+slug: /javascript # Hides folder structure from slug
+title: JavaScript
+description: 'Links to begin learning JavaScript'
+---
+
+## Learning JavaScript
+
+The Mozilla Developer Network [Web Docs](https://developer.mozilla.org/en-US/) is the gold standard for programming on the web. The [JavaScript page](https://developer.mozilla.org/en-US/docs/Learn/JavaScript) is an excellent place for further reading about JavaScript.
+
+## Interactive Tutorials
+
+[Learn JavaScript](https://learnjavascript.online) is an excellent platform for beginning to learn the JavaScript programming language. It is full of interactive tutorials and small projects.

--- a/sidebars.js
+++ b/sidebars.js
@@ -20,7 +20,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Further Reading',
-      items: ['further_reading/version_control'],
+      items: ['further_reading/version_control', 'further_reading/javascript'],
     },
     'prerequisites',
     'troubleshooting',


### PR DESCRIPTION
Adds some external links for learning the basics of JavaScript. Most Honeycomb users have little to no programming experience and these resources seem to be pertinent. I don't think it makes sense for us to write a bunch of our own documentation about JavaScript itself?