### PR TITLE
docs: Add instructions to update the `honeycomb_version` field inside the package.json

### DIFF
--- a/docs/quick_start.mdx
+++ b/docs/quick_start.mdx
@@ -277,8 +277,9 @@ Now that the task is up and running we can make our first changes to the code! W
    1. `name` is your task's name, generally this is the name of our repository
    2. `description` should be rewritten to better match your task
    3. `author` is your lab (or PIs) name, email, and website
-   4. `version` should be reset to 1.0.0
-   5. `repository` is the link the GitHub repository you created [earlier](#2-start-your-new-task-from-our-template-repository).
+   4. `honeycomb_version` is the number currently in the `version` field
+   5. `version` should be reset to 1.0.0
+   6. `repository` is the link the GitHub repository you created [earlier](#2-start-your-new-task-from-our-template-repository).
 
 3. Save your changes and commit them to git:
 

--- a/docs/quick_start.mdx
+++ b/docs/quick_start.mdx
@@ -278,7 +278,6 @@ Now that the task is up and running we can make our first changes to the code! W
    2. `description` should be rewritten to better match your task
    3. `author` is your lab (or PIs) name, email, and website
    4. `honeycombVersion` is the number currently in the `version` field
-
    5. `version` should be reset to 1.0.0
    6. `repository` is the link the GitHub repository you created [earlier](#2-start-your-new-task-from-our-template-repository).
 

--- a/docs/quick_start.mdx
+++ b/docs/quick_start.mdx
@@ -277,7 +277,8 @@ Now that the task is up and running we can make our first changes to the code! W
    1. `name` is your task's name, generally this is the name of our repository
    2. `description` should be rewritten to better match your task
    3. `author` is your lab (or PIs) name, email, and website
-   4. `honeycomb_version` is the number currently in the `version` field
+   4. `honeycombVersion` is the number currently in the `version` field
+
    5. `version` should be reset to 1.0.0
    6. `repository` is the link the GitHub repository you created [earlier](#2-start-your-new-task-from-our-template-repository).
 


### PR DESCRIPTION
My thinking here is that if they don't follow the quick start than most likely the `version` tag will be the Honeycomb version they used. I don't foresee a lab updating the `version` field and not touching `honeycomb_version`

Coincides with [this PR ](https://github.com/brown-ccv/honeycomb/pull/317) in honeycomb.