### PR TITLE
docs: Add page with links to the github dicussions board

### DIFF
--- a/docs/further_reading/github_discussions.mdx
+++ b/docs/further_reading/github_discussions.mdx
@@ -1,0 +1,14 @@
+---
+id: github_discussions
+slug: /github_discussions
+title: Github Discussions
+description: "Links to the Honeycomb repository discussions board and instructions for reporting bugs."
+---
+
+The [Honeycomb repository](https://github.com/brown-ccv/honeycomb) includes a [discussions](https://github.com/brown-ccv/honeycomb/discussions) board. It is a place to ask questions, share ideas, and engage with the community! Official announcements from the project are posted to the [Announcements](https://github.com/brown-ccv/honeycomb/discussions/categories/announcements) section.
+
+Please direct all [feature requests](https://github.com/brown-ccv/honeycomb/discussions/categories/feature-requests) and [questions](https://github.com/brown-ccv/honeycomb/discussions/categories/q-a) to the discussions board.
+
+## Reporting Bugs
+
+Bugs with Honeycomb should be reported directly to the [issues](https://github.com/brown-ccv/honeycomb/issues) tab of the repository. Please select "Bug report" and include as much information as possible. If you are able to provide a minimal example that reproduces the bug, that is even better!

--- a/docs/further_reading/javascript_basics.mdx
+++ b/docs/further_reading/javascript_basics.mdx
@@ -1,8 +1,8 @@
 ---
 id: javascript
-slug: /javascript # Hides folder structure from slug
+slug: /javascript
 title: JavaScript
-description: 'Links to begin learning JavaScript'
+description: "Links to begin learning JavaScript"
 ---
 
 ## Learning JavaScript

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,10 +70,6 @@ module.exports = {
       style: "dark",
       links: [
         {
-          title: "Docs",
-          items: [{ label: "Introduction", to: "docs/" }],
-        },
-        {
           title: "Community",
           items: [
             { label: "GitHub", href: "https://github.com/brown-ccv/honeycomb" },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,6 +76,12 @@ module.exports = {
         {
           title: "Community",
           items: [{ label: "GitHub", href: "https://github.com/brown-ccv/honeycomb" }],
+          items: [
+            {
+              label: "Discussions Board",
+              href: "https://github.com/brown-ccv/honeycomb/discussions",
+            },
+          ],
         },
         {
           title: "Related Publications",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -75,8 +75,8 @@ module.exports = {
         },
         {
           title: "Community",
-          items: [{ label: "GitHub", href: "https://github.com/brown-ccv/honeycomb" }],
           items: [
+            { label: "GitHub", href: "https://github.com/brown-ccv/honeycomb" },
             {
               label: "Discussions Board",
               href: "https://github.com/brown-ccv/honeycomb/discussions",
@@ -84,7 +84,7 @@ module.exports = {
           ],
         },
         {
-          title: "Related Publications",
+          title: "Publications",
           items: [
             {
               label:

--- a/sidebars.js
+++ b/sidebars.js
@@ -35,7 +35,11 @@ module.exports = {
     {
       type: "category",
       label: "Further Reading",
-      items: ["further_reading/version_control", "further_reading/javascript"],
+      items: [
+        "further_reading/github_discussions",
+        "further_reading/version_control",
+        "further_reading/javascript",
+      ],
       description: "Guides pointing to additional resources for further learning",
     },
     "troubleshooting",


### PR DESCRIPTION
- Adds the `/github_discussions` page
- Directs readers to the discussions board for requesting features and asking questions
- Directs readers to the issues page for reporting bugs
- Link to discussions board in the footer
- Removes the "Docs" section of the footer

closes #55 