### PR TITLE
ref(troubleshooting): Add steps for re-setting the node_modules

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -22,7 +22,8 @@ If you run into issues installing Homebrew in step 1 of [Installing Prerequisite
 Run the following command to manually add the Homebrew installation location to your `PATH` so it is available in your shell.
 
 ```shell
-echo 'PATH="/usr/local/bin:$PATH"' >> ~/p.bash_profile
+echo 'PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
+
 ```
 
 :::note

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -23,7 +23,6 @@ Run the following command to manually add the Homebrew installation location to 
 
 ```shell
 echo 'PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
-
 ```
 
 :::note

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -31,11 +31,11 @@ If you're using `zsh`, also add to your `~/.zshrc` file.
 
 ### NPM Errors
 
-Most npm issues can be resolved by re-installing node modules and rebuilding electron. This can be done by running the following commands in the root directory of the project:
+Most npm issues can be resolved by re-installing dependencies and rebuilding electron. This can be done by running the following commands in the root directory of the project:
 
 1. Delete the `node_modules/` folder
-2. Delete hte `package-lock.josn` file
-3. Reinstall the node modules
+2. Delete hte `package-lock.json` file
+3. Reinstall dependencies
    ```shell
    npm install
    ```

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -31,15 +31,11 @@ If you're using `zsh`, also add to your `~/.zshrc` file.
 
 ### NPM Errors
 
-Most npm issues can be resolved by re-installing dependencies and rebuilding electron. This can be done by running the following commands in the root directory of the project:
+Most npm issues can be resolved by re-installing dependencies. This can be done by running the following commands in the root directory of the project:
 
 1. Delete the `node_modules/` folder
 2. Delete hte `package-lock.json` file
 3. Reinstall dependencies
    ```shell
    npm install
-   ```
-4. Rebuild Electron
-   ```shell
-   npm run rebuild
    ```

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -22,7 +22,7 @@ If you run into issues installing Homebrew in step 1 of [Installing Prerequisite
 Run the following command to manually add the Homebrew installation location to your `PATH` so it is available in your shell.
 
 ```shell
-echo 'PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
+echo 'PATH="/usr/local/bin:$PATH"' >> ~/p.bash_profile
 ```
 
 :::note
@@ -31,4 +31,15 @@ If you're using `zsh`, also add to your `~/.zshrc` file.
 
 ### NPM Errors
 
-Try deleting your `node_modules` folder and the `package-lock.json` then running `npm install` then `npm run rebuild`. This should fix most issues.
+Most npm issues can be resolved by re-installing node modules and rebuilding electron. This can be done by running the following commands in the root directory of the project:
+
+1. Delete the `node_modules/` folder
+2. Delete hte `package-lock.josn` file
+3. Reinstall the node modules
+   ```shell
+   npm install
+   ```
+4. Rebuild Electron
+   ```shell
+   npm run rebuild
+   ```


### PR DESCRIPTION
Adds instructions for removing `node_modules/` and re-installing the dependencies. Seems to be a pretty typical reset for npm errors