### PR TITLE
ref: Remove CCV support email

### DIFF
--- a/docs/deployments/firebase.mdx
+++ b/docs/deployments/firebase.mdx
@@ -16,7 +16,9 @@ Honeycomb comes with methods and configurations to deploy tasks with [Firebase](
 ## Setting up Firebase
 
 :::info
-Please have your PI contact [support@ccv.brown.edu](mailto:support@ccv.brown.edu) to create a Firebase project for your Honeycomb task before beginning.
+Members of Brown University should submit a support ticket to have their Firebase project created. Members of other institutions should check to see if their university has access to Google Cloud.
+
+Otherwise, a [personal Firebase account](https://firebase.google.com/) can be created for free. Please follow the [firebase documentation](https://firebase.google.com/docs/projects/learn-more#setting_up_a_firebase_project_and_registering_apps) for creating a new project.
 :::
 
 ### Adding Products

--- a/versioned_docs/version-3.1.x/firebase.mdx
+++ b/versioned_docs/version-3.1.x/firebase.mdx
@@ -16,7 +16,9 @@ Honeycomb comes with methods and configurations to deploy tasks with [Firebase](
 ## Setting up Firebase
 
 :::info
-Please have your PI contact [support@ccv.brown.edu](mailto:support@ccv.brown.edu) to create a Firebase project for your Honeycomb task before beginning.
+Members of Brown University should submit a support ticket to have their Firebase project created. Members of other institutions should check to see if their university has access to Google Cloud.
+
+Otherwise, a [personal Firebase account](https://firebase.google.com/) can be created for free. Please follow the [firebase documentation](https://firebase.google.com/docs/projects/learn-more#setting_up_a_firebase_project_and_registering_apps) for creating a new project.
 :::
 
 ### Adding Products

--- a/versioned_docs/version-3.2.x/deployments/firebase.mdx
+++ b/versioned_docs/version-3.2.x/deployments/firebase.mdx
@@ -16,7 +16,9 @@ Honeycomb comes with methods and configurations to deploy tasks with [Firebase](
 ## Setting up Firebase
 
 :::info
-Please have your PI contact [support@ccv.brown.edu](mailto:support@ccv.brown.edu) to create a Firebase project for your Honeycomb task before beginning.
+Members of Brown University should submit a support ticket to have their Firebase project created. Members of other institutions should check to see if their university has access to Google Cloud.
+
+Otherwise, a [personal Firebase account](https://firebase.google.com/) can be created for free. Please follow the [firebase documentation](https://firebase.google.com/docs/projects/learn-more#setting_up_a_firebase_project_and_registering_apps) for creating a new project.
 :::
 
 ### Adding Products


### PR DESCRIPTION
Note that I removed the email for all of the versioned docs for which it is present
- Removes the CCV support email
- Adds instructions for members of Brown and other universities
- Adds links for creating a Firebase project